### PR TITLE
Replaces `symbolize_names` call with manual reduce...

### DIFF
--- a/lib/facebook-signed-request/signed_request.rb
+++ b/lib/facebook-signed-request/signed_request.rb
@@ -92,10 +92,19 @@ module Facebook
 
     def parse_request_playload
       begin
-        return JSON.parse( @payload, :symbolize_names => true )
+        return JSON.parse(@payload).reduce({}, &symbolize_keys_proc)
       rescue
         @errors << "Invalid JSON object"
         return {}
+      end
+    end
+
+    def symbolize_keys_proc
+      Proc.new do |hash, pair|
+        key, value = pair
+        symbolized_value = value.is_a?(Hash) ? value.reduce({}, &symbolize_keys_proc) : value
+        hash[key.to_sym] = symbolized_value
+        hash
       end
     end
 


### PR DESCRIPTION
... as `symbolize_names` does not work with some JSON gems.
